### PR TITLE
feat: use postcss-preset-env

### DIFF
--- a/packages/porter/package.json
+++ b/packages/porter/package.json
@@ -11,7 +11,6 @@
     "access": "public"
   },
   "dependencies": {
-    "autoprefixer": "^9.3.1",
     "debug": "^3.1.0",
     "glob": "^7.0.5",
     "js-tokens": "^4.0.0",
@@ -21,6 +20,7 @@
     "mz": "^2.6.0",
     "postcss": "^7.0.5",
     "postcss-import": "^12.0.1",
+    "postcss-preset-env": "^6.6.0",
     "rimraf": "^2.6.2",
     "source-map": "^0.7.3",
     "uglify-es": "^3.3.9",

--- a/packages/porter/src/porter.js
+++ b/packages/porter/src/porter.js
@@ -1,13 +1,13 @@
 'use strict'
 
 const atImport = require('postcss-import')
-const autoprefixer = require('autoprefixer')
 const crypto = require('crypto')
 const debug = require('debug')('porter')
 const fs = require('mz/fs')
 const mime = require('mime')
 const path = require('path')
 const postcss = require('postcss')
+const postcssPresetEnv = require('postcss-preset-env')
 const rimraf = require('rimraf')
 const { SourceMapGenerator } = require('source-map')
 const util = require('util')
@@ -22,6 +22,16 @@ const mkdirp = util.promisify(require('mkdirp'))
 const rExt = /\.(?:css|gif|jpg|jpeg|js|png|svg|swf|ico)$/i
 const { rModuleId } = require('./module')
 
+const defaultPresetEnvOpts = {
+  stage: 2,
+  features: {
+    'nesting-rules': true
+  },
+  browserlist: [
+    '> 1%',
+    'not ie < 8'
+  ],
+}
 
 class Porter {
   constructor(opts) {
@@ -63,7 +73,8 @@ class Porter {
         resolve: this.atImportResolve.bind(this)
       })
     )
-    this.cssTranspiler = postcss().use(autoprefixer(opts.autoprefixer))
+
+    this.cssTranspiler = postcss().use(postcssPresetEnv(Object.assign({}, defaultPresetEnvOpts, { autoprefixer : opts.autoprefixer }, opts.postcssPresetEnv)))
     this.ready = this.prepare(opts)
   }
 


### PR DESCRIPTION
使用支持 postcss-preset-env ， 同时 postcss-set-env 自带 autoprefixer 所以无需在需要 autoprefixer