### PR TITLE
模块下载执行完成后，标记 fetching

### DIFF
--- a/packages/porter/loader.js
+++ b/packages/porter/loader.js
@@ -273,6 +273,7 @@
         if (mod.status < MODULE_FETCHED) mod.status = MODULE_FETCHED
         mod.uri = uri
         mod.ignite()
+        fetching[uri] = null
       })
     }
   }


### PR DESCRIPTION
没有直接 delete，如果未来有需要可以 Object.keys(fetching).include(uri) 来判断曾经加载过，不过目前好像没啥用