### PR TITLE
chore: add crossorigin to script for error detection

### DIFF
--- a/packages/porter/loader.js
+++ b/packages/porter/loader.js
@@ -92,6 +92,7 @@
       })
       el.async = true
       el.src = url
+      el.crossOrigin = ''
 
       // baseElement cannot be undefined in IE8-.
       head.insertBefore(el, baseElement)


### PR DESCRIPTION
• 跨域资源引用下，由于浏览器基于安全考虑故意隐藏了其它域JS文件抛出的具体错误信息，前端监控探针只会检测到一个 script error的异常。所以需要增加对于属性