### PR TITLE
fix: loading web worker from dependencies & @babel/runtime issue

### DIFF
--- a/packages/demo-app/.babelrc
+++ b/packages/demo-app/.babelrc
@@ -1,3 +1,6 @@
 {
-  "presets": ["@babel/preset-env"]
+  "presets": ["@babel/preset-env"],
+  "plugins": [
+    "@babel/plugin-transform-runtime"
+  ]
 }

--- a/packages/demo-app/browser_modules/test/suite.js
+++ b/packages/demo-app/browser_modules/test/suite.js
@@ -70,7 +70,7 @@ describe('browser field', function() {
   it('should recognize relative requires without extension', function() {
     // can't reuqire('brotli') directly yet
     // - https://github.com/foliojs/brotli.js/issues/20
-    expect(require('brotli/decompress')).to.a(Function);
+    expect(require('brotli/decompress')).to.be.a(Function);
   });
 
   it('shim stream with readable-stream', function() {
@@ -81,5 +81,14 @@ describe('browser field', function() {
 describe('missing dep', function() {
   it('should still be accessible if requires missing dependency', function() {
     expect(require('./missing.js')).to.eql({});
+  });
+});
+
+describe('worker from dependency', function() {
+  it('should be able to load dependencies that have web workers', async function() {
+    const greeting = require('@cara/demo-worker/');
+    expect(greeting).to.be.a(Function);
+    const result = await greeting();
+    expect(result).to.equal('pong');
   });
 });

--- a/packages/demo-app/components/home_dep.js
+++ b/packages/demo-app/components/home_dep.js
@@ -1,4 +1,3 @@
 'use strict';
 
 console.log('home_dep');
-/* changed kw0eorfp */

--- a/packages/demo-app/package.json
+++ b/packages/demo-app/package.json
@@ -5,7 +5,10 @@
   "private": true,
   "dependencies": {
     "@babel/core": "^7.16.0",
+    "@babel/plugin-transform-runtime": "^7.16.4",
     "@babel/preset-env": "^7.1.0",
+    "@cara/demo-worker": "^3.3.0",
+    "@cara/demo-wasm": "^3.3.0",
     "@cara/porter": "^3.3.0",
     "brotli": "^1.3.2",
     "buffer": "^5.2.1",

--- a/packages/demo-worker/index.js
+++ b/packages/demo-worker/index.js
@@ -1,0 +1,14 @@
+'use strict';
+
+const Worker = require('worker-loader!./components/worker.js');
+
+const worker= new Worker();
+
+module.exports = function greeting() {
+  return new Promise(function(resolve) {
+    worker.onmessage = function(message) {
+      resolve(message.data);
+    };
+    worker.postMessage('ping');
+  });
+};

--- a/packages/porter-cli/test/porter-serve.test.js
+++ b/packages/porter-cli/test/porter-serve.test.js
@@ -5,6 +5,7 @@ const expect = require('expect.js');
 const http = require('http');
 const path = require('path');
 const { spawn } = require('child_process');
+const fs = require('fs/promises');
 
 const cmd = path.join(__dirname, '../bin/porter-serve.js');
 const componentRoot = path.join(__dirname, '../../demo-component');
@@ -129,6 +130,10 @@ describe('porter-serve web application', function() {
 });
 
 describe('porter-serve web application --headless', function() {
+  before(async function() {
+    await fs.rm(path.join(appRoot, 'public'), { recursive: true, force: true });
+  });
+
   it('should be able to run web application tests headlessly', async function() {
     const proc = spawn(cmd, [
       '--paths', 'components',

--- a/packages/porter/loader.js
+++ b/packages/porter/loader.js
@@ -434,7 +434,8 @@
     if (map.folder && map.folder[file]) file += '/index.js';
 
     file = suffix(file);
-    return name === pkg.name ? file : resolve(name, version, file);
+    var id = resolve(name, version, file);
+    return name === pkg.name && !registry[id] ? file : id;
   };
 
 
@@ -486,7 +487,7 @@
     'import': function Porter_import(specifiers, fn) {
       specifiers = preload.concat(specifiers).map(function(specifier) {
         var mod = parseId(specifier);
-        return suffix(mod.version ? mod.file : specifier);
+        return suffix(mod.version && !registry[specifier] ? mod.file : specifier);
       });
       rootImport(specifiers, function() {
         if (fn) fn.apply(null, arrayFn.slice.call(arguments, preload.length));

--- a/packages/porter/src/css_module.js
+++ b/packages/porter/src/css_module.js
@@ -39,7 +39,7 @@ module.exports = class CssModule extends Module {
     const code = this.code || await readFile(fpath, 'utf8');
 
     const { id } = this;
-    const { cssLoader, root } = this.package.app;
+    const { cssLoader } = this.package.app;
 
     /**
      * `from` must be absolute path to make sure the `baseDir` in
@@ -53,7 +53,6 @@ module.exports = class CssModule extends Module {
       to: id,
       map: {
         inline: false,
-        from: path.relative(root, fpath),
         sourcesContent: false
       }
     });

--- a/packages/porter/src/js_module.js
+++ b/packages/porter/src/js_module.js
@@ -83,7 +83,6 @@ module.exports = class JsModule extends Module {
   }
 
   async transpile({ code, map }) {
-    const { id, deps } = this;
     let result;
 
     try {
@@ -95,10 +94,17 @@ module.exports = class JsModule extends Module {
 
     // if fpath is ignored, @babel/core returns nothing
     if (result) {
+      const { deps } = this;
+      // @babel/runtime
+      this.deps = this.matchImport(result.code);
+      for (const dep of this.deps) {
+        if (!deps.includes(dep)) await this.parseDep(dep);
+      }
       code = result.code;
       map = result.map;
     }
 
+    const { id, deps } = this;
     return {
       code: [
         `define(${JSON.stringify(id)}, ${JSON.stringify(deps)}, function(require, exports, module, __module) {${code}`,

--- a/packages/porter/test/integration/porter.test.js
+++ b/packages/porter/test/integration/porter.test.js
@@ -29,7 +29,8 @@ function requestPath(urlPath, status = 200, listener = app.callback()) {
 async function checkReload({ sourceFile, targetFile, pathname }) {
   sourceFile = sourceFile || targetFile;
   const sourceModule = await porter.package.parseFile(sourceFile);
-  const targetModule = await porter.package.parseFile(targetFile);
+  const targetModule = await porter.package.parseEntry(targetFile);
+  await porter.pack();
   pathname = pathname || `/${targetModule.id}`;
 
   const { fpath: sourcePath } = sourceModule;
@@ -54,7 +55,6 @@ async function checkReload({ sourceFile, targetFile, pathname }) {
     assert((await readFile(cachePath, 'utf8')).includes(mark));
   } finally {
     await writeFile(sourcePath, source);
-    await new Promise(resolve => setTimeout(resolve, 200));
   }
 }
 
@@ -68,6 +68,7 @@ describe('Porter', function() {
         root: 'http://localhost:5000'
       }
     });
+    await fs.rm(porter.cache.dest, { recursive: true, force: true });
     await porter.ready;
 
     app = new Koa();

--- a/packages/porter/test/unit/bundle.test.js
+++ b/packages/porter/test/unit/bundle.test.js
@@ -42,6 +42,13 @@ describe('Bundle without preload', function() {
         if (dep !== porter.package) assert.ok(dep.bundle);
       }
     });
+
+    it('should append @babel/runtime', async function() {
+      // injected by @babel/plugin-transform-runtime
+      const runtime = porter.package.find({ name: '@babel/runtime' });
+      assert.ok(runtime.bundle);
+      assert.ok(runtime.bundle.output);
+    });
   });
 });
 
@@ -93,7 +100,7 @@ describe('Bundle with preload', function() {
       assert.ok(reactModules.every(mod => !modules.includes(mod)));
       assert.ok(reactModules.every(mod => !preloadModules.includes(mod)));
       assert.equal(react.bundle.entry, react.main);
-      assert.equal(react.bundle.output.replace(/.[a-z0-9]{8}/, ''), react.main);
+      assert.equal(react.bundle.output.replace(/.[a-f0-9]{8}/, ''), react.main);
     });
 
     it('should still preload dependencies of isolated dependencies', async function() {
@@ -107,7 +114,7 @@ describe('Bundle with preload', function() {
     it('should work', async function() {
       const bundle = porter.package.bundles['home.js'];
       const { entry, output } = bundle;
-      assert.ok(new RegExp(`^${entry.replace('.js', '.[a-z0-9]{8}.js')}$`).test(output));
+      assert.ok(new RegExp(`^${entry.replace('.js', '.[a-f0-9]{8}.js')}$`).test(output));
     });
   });
 });

--- a/packages/porter/test/unit/compile_all.test.js
+++ b/packages/porter/test/unit/compile_all.test.js
@@ -2,14 +2,16 @@
 
 const path = require('path');
 const { strict: assert } = require('assert');
-const exec = require('child_process').execSync;
 const util = require('util');
-const { existsSync, promises: { readFile } } = require('fs');
+const { existsSync, promises: fs } = require('fs');
 const glob = util.promisify(require('glob'));
 
 const Porter = require('../..');
+const { readFile } = fs;
 
 describe('porter.compileAll()', function() {
+  // compiling without cache could be time consuming
+  this.timeout(600000);
   const root = path.resolve(__dirname, '../../../demo-app');
   const dest = path.join(root, 'public');
   let porter;
@@ -24,8 +26,9 @@ describe('porter.compileAll()', function() {
       lazyload: ['lazyload.js'],
       source: { root: 'http://localhost:3000/' }
     });
+    await fs.rm(porter.cache.dest, { recursive: true, force: true });
     await porter.ready;
-    exec(`rm -rf ${dest}`);
+
     await porter.compileAll({
       entries: ['home.js', 'test/suite.js', 'stylesheets/app.css']
     });

--- a/packages/porter/test/unit/packet.test.js
+++ b/packages/porter/test/unit/packet.test.js
@@ -157,6 +157,14 @@ describe('Packet', function() {
         expect(semver.satisfies(deps[name], pkg[name]));
       }
     });
+
+    it('should contain @babel/runtime manifest', async function() {
+      const { lock } = porter.package;
+      assert.ok(lock['@babel/runtime']);
+      // { manifest: { 'index.js': 'index.fc8964e4.js' } }
+      const meta = Object.values(lock['@babel/runtime']).shift();
+      assert.equal(Object.keys(meta.manifest).length, 1);
+    });
   });
 
   describe('package.compile()', function () {


### PR DESCRIPTION
```js
import Worker from 'worker-loader!@cara/demo-worker/components/worker.js';
```

Bundling strategy is changed a bit too, with worker entries ignoring preload settings and have all the dependencies bundled.