### PR TITLE
fix: sources in source map generated by css and js transpiler

### DIFF
--- a/packages/demo-app/package.json
+++ b/packages/demo-app/package.json
@@ -7,6 +7,7 @@
     "@babel/core": "^7.16.0",
     "@babel/plugin-transform-runtime": "^7.16.4",
     "@babel/preset-env": "^7.1.0",
+    "@babel/runtime": "^7.16.3",
     "@cara/demo-worker": "^3.3.0",
     "@cara/demo-wasm": "^3.3.0",
     "@cara/porter": "^3.3.0",

--- a/packages/porter/package.json
+++ b/packages/porter/package.json
@@ -26,13 +26,13 @@
     "uglify-js": "^3.14.3"
   },
   "devDependencies": {
+    "cssnano": "^5.0.11",
     "expect.js": "^0.3.1",
     "express": "^4.17.1",
     "koa": "^2.13.4",
     "mocha": "^9.1.1",
     "nyc": "^13.1.0",
-    "postcss-clean": "1.2.0",
-    "postcss-preset-env": "^6.7.0",
+    "postcss-preset-env": "^7.0.1",
     "semver": "^4.3.6",
     "sinon": "^12.0.1",
     "supertest": "^6.1.6"

--- a/packages/porter/src/js_module.js
+++ b/packages/porter/src/js_module.js
@@ -128,7 +128,7 @@ module.exports = class JsModule extends Module {
   }
 
   async _transpile({ code, }) {
-    const { fpath, package: pkg } = this;
+    const { fpath, package: pkg, app } = this;
     const babel = pkg.transpiler === 'babel' && pkg.tryRequire('@babel/core');
     if (!babel) return;
 
@@ -139,26 +139,16 @@ module.exports = class JsModule extends Module {
      */
     if (!fpath.startsWith(pkg.dir)) return;
 
-    const transpileOptions = {
-      plugins: [],
+    const transpilerOptions = {
       ...pkg.transpilerOpts,
       sourceMaps: true,
       sourceRoot: '/',
       ast: false,
       filename: fpath,
-      filenameRelative: path.relative(pkg.dir, fpath),
-      sourceFileName: path.relative(pkg.dir, fpath),
-      // root: pkg.dir
+      filenameRelative: path.relative(app.root, fpath),
+      sourceFileName: path.relative(app.root, fpath),
     };
-    const { plugins } = transpileOptions;
-
-    for (const name of [ '@cara/babel-plugin-import-meta', '@cara/babel-plugin-deheredoc' ]) {
-      if (!plugins.some(plugin => plugin.includes(name))) {
-        plugins.push(require.resolve(name));
-      }
-    }
-
-    return await babel.transform(code, transpileOptions);
+    return await babel.transform(code, transpilerOptions);
   }
 
   uglify({ code, map }) {

--- a/packages/porter/src/module.js
+++ b/packages/porter/src/module.js
@@ -3,10 +3,7 @@
 const crypto = require('crypto');
 const debug = require('debug')('porter');
 const path = require('path');
-const { promises: { writeFile } } = require('fs');
-const util = require('util');
-
-const mkdirp = util.promisify(require('mkdirp'));
+const fs = require('fs/promises');
 
 const rModuleId = /^((?:@[^\/]+\/)?[^\/]+)(?:\/(\d+\.\d+\.\d+[^\/]*))?(?:\/(.*))?$/;
 
@@ -18,6 +15,7 @@ module.exports = class Module {
     if (moduleCache[fpath]) return moduleCache[fpath];
     moduleCache[fpath] = this;
 
+    this.app = pkg.app;
     this.package = pkg;
     this.name = pkg.name;
     this.version = pkg.version;
@@ -89,8 +87,8 @@ module.exports = class Module {
     const fpath = path.join(this.package.app.cache.dest, this.id);
     const dir = path.dirname(fpath);
 
-    await mkdirp(dir);
-    await writeFile(`${fpath}.cache`, JSON.stringify(this.cache));
+    await fs.mkdir(dir, { recursive: true });
+    await fs.writeFile(`${fpath}.cache`, JSON.stringify(this.cache));
   }
 
   addCache(source, opts) {

--- a/packages/porter/src/porter.js
+++ b/packages/porter/src/porter.js
@@ -54,14 +54,13 @@ class Porter {
     this.lazyload = [].concat(opts.lazyload || []);
 
     this.source = { serve: false, root: '/', ...opts.source };
-    this.cssLoader = postcss([
+    this.cssTranspiler = postcss([
       atImport({
         path: paths,
         resolve: this.atImportResolve.bind(this)
-      })
+      }),
+      ...(opts.postcssPlugins || [ autoprefixer(opts.autoprefixer) ]),
     ]);
-
-    this.cssTranspiler = postcss(opts.postcssPlugins || [autoprefixer(opts.autoprefixer)]);
     this.ready = this.prepare(opts);
   }
 

--- a/packages/porter/test/unit/js_module.test.js
+++ b/packages/porter/test/unit/js_module.test.js
@@ -1,0 +1,33 @@
+'use strict';
+
+const { strict: assert } = require('assert');
+const path = require('path');
+const fs = require('fs/promises');
+const Porter = require('../..');
+
+describe('JsModule', function() {
+  const root = path.resolve(__dirname, '../../../demo-app');
+  let porter;
+
+  before(async function() {
+    porter = new Porter({
+      root,
+      paths: ['components', 'browser_modules'],
+      entries: ['home.js', 'test/suite.js'],
+      transpile: { only: [ 'yen' ] },
+    });
+    await fs.rm(porter.cache.dest, { recursive: true, force: true });
+    await porter.ready;
+  });
+
+  after(async function() {
+    await porter.destroy();
+  });
+
+  it('should transpile dependencies with correct source map', async function() {
+    const pkg = porter.package.find({ name: 'yen' });
+    const mod = pkg.files['events.js'];
+    const { map } = await mod.obtain();
+    assert.deepEqual(map.sources, [ 'node_modules/yen/events.js' ]);
+  });
+});


### PR DESCRIPTION
- sources should point to the correct paths relative to app.root
- replaced postcss-clean in the css transpiler test case because cssnano looks way more promising
