### PR TITLE
fix: compilation output of ts entries should be `.js`

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -5,9 +5,9 @@ name: Node.js CI
 
 on:
   push:
-    branches: [ master ]
+    branches: [ master, v3.x ]
   pull_request:
-    branches: [ master ]
+    branches: [ master, v3.x ]
 
 jobs:
   build:

--- a/packages/porter/src/packet.js
+++ b/packages/porter/src/packet.js
@@ -227,7 +227,7 @@ module.exports = class Package {
     const { dest } = app.cache;
     const purge = id => {
       const fpath = path.join(dest, id);
-      debug('purge cache %s', fpath)
+      debug('purge cache %s', fpath);
       return fs.unlink(fpath).catch(() => {});
     };
 
@@ -663,7 +663,7 @@ module.exports = class Package {
       this.bundleEntry = `~bundle-${crypto.createHash('md5').update(result.code).digest('hex').slice(0, 8)}.js`;
       file = this.bundleEntry;
     }
-    const fpath = path.join(dest, name, version, file);
+    const fpath = path.join(dest, name, version, file.replace(/\.(?:jsx?|tsx?)$/, '.js'));
 
     await mkdirp(path.dirname(fpath));
     await Promise.all([

--- a/packages/porter/src/porter.js
+++ b/packages/porter/src/porter.js
@@ -144,7 +144,6 @@ class Porter {
   async compileExclusivePackages(opts) {
     for (const name of this.bundleExcept) {
       const packages = this.package.findAll({ name });
-      if (packages.length == 0) throw new Error(`unable to find package ${name}`);
       for (const pkg of packages) await pkg.compileAll(opts);
     }
   }

--- a/packages/porter/test/ts_module.test.js
+++ b/packages/porter/test/ts_module.test.js
@@ -2,7 +2,8 @@
 
 const path = require('path');
 const { strict: assert } = require('assert');
-const Porter = require("../src/porter");
+const fs = require('fs/promises');
+const Porter = require('../src/porter');
 
 const root = path.resolve(__dirname, '../../demo-typescript');
 const porter = new Porter({
@@ -12,6 +13,7 @@ const porter = new Porter({
 
 describe('TsModule', function() {
   before(async function() {
+    await fs.rm(porter.cache.dest, { recursive: true, force: true });
     await porter.ready;
   });
 


### PR DESCRIPTION
when partial compiling, exclusive packages might not be loaded, which should be skipped.