### PR TITLE
fix: drop the default autoprefixer & unused dependency

### DIFF
--- a/packages/porter/package.json
+++ b/packages/porter/package.json
@@ -11,7 +11,6 @@
     "access": "public"
   },
   "dependencies": {
-    "autoprefixer": "^10.3.5",
     "debug": "^3.1.0",
     "glob": "^7.0.5",
     "js-tokens": "^4.0.0",
@@ -21,7 +20,6 @@
     "mz": "^2.6.0",
     "postcss": "^8.2.10",
     "postcss-import": "^12.0.1",
-    "postcss-loader": "^6.1.1",
     "rimraf": "^2.6.2",
     "source-map": "^0.7.3",
     "uglify-es": "^3.3.9",

--- a/packages/porter/src/porter.js
+++ b/packages/porter/src/porter.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const atImport = require('postcss-import');
-const autoprefixer = require('autoprefixer');
 const crypto = require('crypto');
 const debug = require('debug')('porter');
 const fs = require('mz/fs');
@@ -64,9 +63,7 @@ class Porter {
       })
     ]);
 
-    this.cssTranspiler = postcss(
-      (opts.postcssPlugins || []).concat(autoprefixer(opts.autoprefixer))
-    );
+    this.cssTranspiler = postcss(opts.postcssPlugins || []);
     this.ready = this.prepare(opts);
   }
 


### PR DESCRIPTION
which might have its appearance order changed in actual postcss plugins