### PR TITLE
fix: porter.pack() should ignore incomplete modules

### DIFF
--- a/packages/porter/src/constants.js
+++ b/packages/porter/src/constants.js
@@ -1,0 +1,11 @@
+'use strict';
+
+const MODULE_INIT = 0;
+const MODULE_LOADING = 1;
+const MODULE_LOADED = 2;
+
+module.exports = {
+  MODULE_INIT,
+  MODULE_LOADING,
+  MODULE_LOADED,
+};

--- a/packages/porter/src/js_module.js
+++ b/packages/porter/src/js_module.js
@@ -9,6 +9,8 @@ const { promises: { readFile } } = require('fs');
 const Module = require('./module');
 const matchRequire = require('./match_require');
 
+const { MODULE_LOADING, MODULE_LOADED } = require('./constants');
+
 module.exports = class JsModule extends Module {
   matchImport(code) {
     const { package: pkg } = this;
@@ -55,8 +57,8 @@ module.exports = class JsModule extends Module {
    * parse the module code and contruct dependencies.
    */
   async parse() {
-    if (this.loaded) return;
-    this.loaded = true;
+    if (this.status >= MODULE_LOADING) return;
+    this.status = MODULE_LOADING;
 
     const { package: pkg, app } = this;
     const { code } = await this.load();
@@ -80,6 +82,7 @@ module.exports = class JsModule extends Module {
     }
 
     await Promise.all(deps.map(this.parseDep, this));
+    this.status = MODULE_LOADED;
   }
 
   async load() {

--- a/packages/porter/src/module.js
+++ b/packages/porter/src/module.js
@@ -4,6 +4,7 @@ const crypto = require('crypto');
 const debug = require('debug')('porter');
 const path = require('path');
 const fs = require('fs/promises');
+const { MODULE_INIT } = require('./constants');
 
 const rModuleId = /^((?:@[^\/]+\/)?[^\/]+)(?:\/(\d+\.\d+\.\d+[^\/]*))?(?:\/(.*))?$/;
 
@@ -24,6 +25,7 @@ module.exports = class Module {
     this.fpath = fpath;
     this.children = [];
     this.entries = [];
+    this.status = MODULE_INIT;
   }
 
   get id() {
@@ -103,7 +105,7 @@ module.exports = class Module {
     const { package: pkg } = this;
     const file = path.join(path.dirname(this.file), dep);
 
-    return pkg.parseFile(file);
+    return await pkg.parseFile(file);
   }
 
   async parseNonRelative(dep) {
@@ -187,8 +189,6 @@ module.exports = class Module {
    * @returns {Array}
    */
   async checkDeps({ code }) {
-    if (this.file.endsWith('.css')) return [null, false];
-
     const deps = this.matchImport(code);
 
     if (!this.package.parent && this.deps) {

--- a/packages/porter/src/porter.js
+++ b/packages/porter/src/porter.js
@@ -17,6 +17,7 @@ const Package = require('./packet');
 const rExt = /\.(?:css|gif|jpg|jpeg|js|png|svg|swf|ico)$/i;
 const { rModuleId } = require('./module');
 const Bundle = require('./bundle');
+const { MODULE_LOADED } = require('./constants');
 
 class Porter {
   constructor(opts) {
@@ -103,6 +104,9 @@ class Porter {
     }
 
     for (const file of preload.concat(entries)) {
+      const mod = pkg.files[file];
+      // module might not ready yet
+      if (mod.status < MODULE_LOADED) continue;
       const bundle = pkg.bundles[file] || Bundle.create({ packet: pkg, entries: [ file ] });
       await bundle.obtain();
     }

--- a/packages/porter/test/unit/css_module.test.js
+++ b/packages/porter/test/unit/css_module.test.js
@@ -7,7 +7,7 @@ const cssnano = require('cssnano');
 const fs = require('fs/promises');
 
 const Porter = require('../..');
-
+const { MODULE_LOADED } = require('../../src/constants');
 
 describe('CssModule', function() {
   const root = path.resolve(__dirname, '../../../demo-app');
@@ -53,5 +53,10 @@ describe('CssModule', function() {
       'node_modules/prismjs/themes/prism.css',
       'components/stylesheets/app.css',
     ]);
+  });
+
+  it('should set status to MODULE_LOADED after parse', async function() {
+    const mod = porter.package.files['stylesheets/app.css'];
+    assert.equal(mod.status, MODULE_LOADED);
   });
 });

--- a/packages/porter/test/unit/js_module.test.js
+++ b/packages/porter/test/unit/js_module.test.js
@@ -4,6 +4,7 @@ const { strict: assert } = require('assert');
 const path = require('path');
 const fs = require('fs/promises');
 const Porter = require('../..');
+const { MODULE_LOADED } = require('../../src/constants');
 
 describe('JsModule', function() {
   const root = path.resolve(__dirname, '../../../demo-app');
@@ -39,5 +40,10 @@ describe('JsModule', function() {
     await assert.doesNotReject(async function() {
       await mod.parse();
     });
+  });
+
+  it('should set status to MODULE_LOADED after parse', async function() {
+    const mod = porter.package.files['home.js'];
+    assert.equal(mod.status, MODULE_LOADED);
   });
 });


### PR DESCRIPTION
for example, when requesting /entry.css and /entry.js simutaneously, and porter starts packing bundles for entry.css, entry.js might be added to porter.entries already but the module isn't fully parsed yet. It should be ignored, and left to the second packing iteration.

Otherwise the packed entry.js is incomplete