### PR TITLE
fix: require('heredoc').strip

### DIFF
--- a/packages/porter/src/babel_plugin.js
+++ b/packages/porter/src/babel_plugin.js
@@ -27,7 +27,8 @@ module.exports = function({ types: t }) {
     VariableDeclaration(path) {
       const { node } = path;
       const { init } = node.declarations[0];
-      if (t.isCallExpression(init) && init.callee.name === 'require' && init.arguments[0].value === 'heredoc') {
+      const expr = t.isMemberExpression(init) ? init.object : init;
+      if (t.isCallExpression(expr) && expr.callee.name === 'require' && expr.arguments[0].value === 'heredoc') {
         path.remove();
       }
     },

--- a/packages/porter/src/json_module.js
+++ b/packages/porter/src/json_module.js
@@ -3,10 +3,12 @@
 const { promises: { readFile } } = require('fs');
 
 const Module = require('./module');
+const { MODULE_LOADED } = require('./constants');
 
 module.exports = class JsonModule extends Module {
   async parse() {
     // nothing to parse here, just pure json data
+    this.status = MODULE_LOADED;
   }
 
   matchImport() {

--- a/packages/porter/src/wasm_module.js
+++ b/packages/porter/src/wasm_module.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const { promises: { readFile } } = require('fs');
+const { MODULE_LOADED } = require('./constants');
 const Module = require('./module');
 
 module.exports = class WasmModule extends Module {
@@ -14,6 +15,7 @@ module.exports = class WasmModule extends Module {
 
   async parse() {
     // unnecessary
+    this.status = MODULE_LOADED;
   }
 
   matchImport() {

--- a/packages/porter/test/unit/babel_plugin.test.js
+++ b/packages/porter/test/unit/babel_plugin.test.js
@@ -13,6 +13,14 @@ describe('test/deheredoc.test.js', function() {
     assert.equal(result.code, 'const a = 1;');
   });
 
+  it('should remove require("heredoc").strip', function() {
+    const result = babel.transform(`
+    const heredoc = require('heredoc').strip;
+    const a = 1;
+  `, { plugins: [ plugin ] });
+  assert.equal(result.code, 'const a = 1;');
+  });
+
   it('should replace heredoc(function() {/* text */}) with text', function() {
     const result = babel.transform(`
       function foo() {

--- a/packages/porter/test/unit/json_module.test.js
+++ b/packages/porter/test/unit/json_module.test.js
@@ -1,0 +1,31 @@
+'use strict';
+
+const { strict: assert } = require('assert');
+const path = require('path');
+const fs = require('fs/promises');
+const Porter = require('../..');
+const { MODULE_LOADED } = require('../../src/constants');
+
+describe('WasmModule', function() {
+  const root = path.resolve(__dirname, '../../../demo-app');
+  let porter;
+
+  before(async function() {
+    porter = new Porter({
+      root,
+      paths: ['components', 'browser_modules'],
+      entries: ['home.js', 'test/suite.js'],
+    });
+    await fs.rm(porter.cache.dest, { recursive: true, force: true });
+    await porter.ready;
+  });
+
+  after(async function() {
+    await porter.destroy();
+  });
+
+  it('should be able to parse json module', async function() {
+    const mod = porter.package.files['require-json/foo.json'];
+    assert.equal(mod.status, MODULE_LOADED);
+  });
+});

--- a/packages/porter/test/unit/wasm_module.test.js
+++ b/packages/porter/test/unit/wasm_module.test.js
@@ -1,0 +1,32 @@
+'use strict';
+
+const { strict: assert } = require('assert');
+const path = require('path');
+const fs = require('fs/promises');
+const Porter = require('../..');
+const { MODULE_LOADED } = require('../../src/constants');
+
+describe('WasmModule', function() {
+  const root = path.resolve(__dirname, '../../../demo-wasm');
+  let porter;
+
+  before(async function() {
+    porter = new Porter({
+      root,
+      entries: [ 'home.js' ],
+    });
+    await fs.rm(porter.cache.dest, { recursive: true, force: true });
+    await porter.ready;
+  });
+
+  after(async function() {
+    await porter.destroy();
+  });
+
+  it('should be able to parse wasm module', async function() {
+    const packet = porter.package.find({ name: '@cara/hello-wasm' });
+    // the parsing process is deferred
+    const mod = await packet.parseFile('hello_wasm_bg.wasm');
+    assert.equal(mod.status, MODULE_LOADED);
+  });
+});


### PR DESCRIPTION
also fixed `packet.pack()`, when the packet takes too much time to parse, `packet.pack()` might be called earlier. In such case, a wait poll is necessary.