### PR TITLE
fix: override inlineSourceMap option to force source map

### DIFF
--- a/packages/demo-typescript/tsconfig.json
+++ b/packages/demo-typescript/tsconfig.json
@@ -4,7 +4,7 @@
     "module": "commonjs",
     "target": "ES2015",
     "noImplicitAny": true,
-    "sourceMap": true,
+    "inlineSourceMap": true,
     "esModuleInterop": true,
     "jsx": "react",
     "allowJs": true,

--- a/packages/porter/test/unit/ts_module.test.js
+++ b/packages/porter/test/unit/ts_module.test.js
@@ -38,4 +38,12 @@ describe('TsModule', function() {
       'components/home.tsx',
     ]);
   });
+
+  it('should generate source map', async function() {
+    const mod = porter.packet.files['app.tsx'];
+    const { code, map } = await mod.obtain();
+    assert.equal(typeof code, 'string');
+    assert.equal(typeof map, 'object');
+    assert.equal(map.file, path.relative(root, mod.fpath));
+  });
 });


### PR DESCRIPTION
otherwise sourceMapText would be undefined because it is inlined in transpile code already