### PR TITLE
fix: intermediate css source map should not have full sourceRoot

### DIFF
--- a/packages/porter/src/css_module.js
+++ b/packages/porter/src/css_module.js
@@ -65,7 +65,7 @@ module.exports = class CssModule extends Module {
     });
 
     map = JSON.parse(result.map);
-    map.sourceRoot = app.source.root;
+    map.sourceRoot = '/';
     map.sources = map.sources.map(source => {
       return path.relative(app.root, source.replace(/^file:/, ''));
     });

--- a/packages/porter/test/unit/css_module.test.js
+++ b/packages/porter/test/unit/css_module.test.js
@@ -54,6 +54,7 @@ describe('CssModule', function() {
     assert.deepEqual(map.sources, [
       'components/stylesheets/app.css',
     ]);
+    assert.equal(map.sourceRoot, '/');
   });
 
   it('should set status to MODULE_LOADED after parse', async function() {


### PR DESCRIPTION
setting the intermediate source root to `/` shall suffice. The `options.source.root` will be set to the source map of bundle output afterwards.