### PR TITLE
feat: new Porter({ bundle: { async exists(bundle): boolean });

### DIFF
--- a/packages/porter/src/cache.js
+++ b/packages/porter/src/cache.js
@@ -65,7 +65,7 @@ module.exports = class Cache {
     const saltPath = path.join(this.path, 'salt.cache');
     const salt = await fs.readFile(saltPath, 'utf8').catch(() => '');
     if (salt !== this.salt) {
-      debug('cache salt changed from %j to %j', salt, this.salt);
+      if (salt) debug('cache salt changed from %j to %j', salt, this.salt);
       await fs.mkdir(path.dirname(saltPath), { recursive: true });
       await fs.writeFile(saltPath, this.salt);
     }

--- a/packages/porter/src/js_module.js
+++ b/packages/porter/src/js_module.js
@@ -107,7 +107,6 @@ module.exports = class JsModule extends Module {
       for (const dep of this.deps) {
         if (!deps.includes(dep)) await this.parseDep(dep);
       }
-      if (!this.packet) console.log(deps, this.deps);
       code = result.code;
       map = result.map;
     }

--- a/packages/porter/test/integration/porter.test.js
+++ b/packages/porter/test/integration/porter.test.js
@@ -65,7 +65,7 @@ describe('Porter', function() {
       }
     });
     await fs.rm(porter.cache.path, { recursive: true, force: true });
-    await porter.ready;
+    await porter.ready();
 
     app = new Koa();
     app.use(porter.async());
@@ -138,7 +138,7 @@ describe('Porter', function() {
     it('should handle packet manifest', async function() {
       const yen = porter.packet.find({ name: 'yen' });
       const { name, version, main } = yen;
-      const { manifest } = porter.packet.lock[name][version];
+      const { manifest } = yen.copy;
       await requestPath(`/${name}/${version}/${manifest[main]}`);
     });
 

--- a/packages/porter/test/integration/porter_lazyload.test.js
+++ b/packages/porter/test/integration/porter_lazyload.test.js
@@ -19,7 +19,7 @@ app.use(porter.async());
 describe('Porter_readFile()', function() {
   before(async function() {
     await fs.rm(porter.cache.path, { recursive: true, force: true });
-    await porter.ready;
+    await porter.ready();
   });
 
   after(async function() {

--- a/packages/porter/test/integration/porter_preload.test.js
+++ b/packages/porter/test/integration/porter_preload.test.js
@@ -53,7 +53,7 @@ async function checkReload({ packet = porter.packet, sourceFile, targetFile, pat
 describe('Porter_readFile()', function() {
   before(async function() {
     await fs.rm(porter.cache.path, { recursive: true, force: true });
-    await porter.ready;
+    await porter.ready();
   });
 
   after(async function() {

--- a/packages/porter/test/unit/bundle.test.js
+++ b/packages/porter/test/unit/bundle.test.js
@@ -17,7 +17,7 @@ describe('Bundle without preload', function() {
       entries: ['home.js', 'test/suite.js', 'stylesheets/app.css'],
     });
     await fs.rm(porter.cache.path, { recursive: true, force: true });
-    await porter.ready;
+    await porter.ready();
   });
 
   after(async function() {
@@ -29,6 +29,7 @@ describe('Bundle without preload', function() {
       assert.deepEqual(Object.keys(porter.packet.bundles).sort(), [
         'home.js',
         'lazyload.js',
+        'lazyload_dep.js',
         'stylesheets/app.css',
         'test/suite.js',
       ]);
@@ -107,7 +108,7 @@ describe('Bundle with preload', function() {
         exclude: ['react', 'react-dom', 'chart.js'],
       },
     });
-    await porter.ready;
+    await porter.ready();
   });
 
   after(async function() {
@@ -189,6 +190,16 @@ describe('Bundle with preload', function() {
       ]);
     });
   });
+
+  describe('bundle.fuzzyObtain()', function() {
+    it('should return the same code as from bundle.obtain()', async function() {
+      const bundle = porter.packet.bundles['home.js'];
+      const result = await bundle.fuzzyObtain();
+      const result2 = await bundle.obtain();
+      assert.equal(result.code, result2.code);
+      assert.ok(result2.map);
+    });
+  });
 });
 
 describe('Bundle with TypeScript', function() {
@@ -201,7 +212,7 @@ describe('Bundle with TypeScript', function() {
       entries: ['app.tsx', 'app.css'],
     });
     await fs.rm(porter.cache.path, { recursive: true, force: true });
-    await porter.ready;
+    await porter.ready();
   });
 
   after(async function() {
@@ -241,7 +252,7 @@ describe('Bundle with CSS in JS', function() {
       },
     });
     await fs.rm(porter.cache.path, { recursive: true, force: true });
-    await porter.ready;
+    await porter.ready();
   });
 
   after(async function() {

--- a/packages/porter/test/unit/compile_all.test.js
+++ b/packages/porter/test/unit/compile_all.test.js
@@ -28,7 +28,7 @@ describe('porter.compileAll()', function() {
       bundle: { exclude: [ 'react', 'react-dom' ] },
     });
     await fs.rm(porter.cache.path, { recursive: true, force: true });
-    await porter.ready;
+    await porter.ready();
 
     await porter.compileAll({
       entries: ['home.js', 'test/suite.js', 'stylesheets/app.css']

--- a/packages/porter/test/unit/compile_entry.test.js
+++ b/packages/porter/test/unit/compile_entry.test.js
@@ -11,7 +11,7 @@ describe('porter.compileEntry()', function() {
 
   before(async function() {
     porter = new Porter({ root, preload: 'preload' });
-    await porter.ready;
+    await porter.ready();
   });
 
   after(async function() {

--- a/packages/porter/test/unit/css_module.test.js
+++ b/packages/porter/test/unit/css_module.test.js
@@ -24,7 +24,7 @@ describe('CssModule', function() {
       ],
     });
     await fs.rm(porter.cache.path, { recursive: true, force: true });
-    await porter.ready;
+    await porter.ready();
   });
 
   after(async function() {

--- a/packages/porter/test/unit/fake_packet.test.js
+++ b/packages/porter/test/unit/fake_packet.test.js
@@ -13,7 +13,7 @@ describe('FakePacket', function() {
     target = new Porter({
       root: path.join(__dirname, '../../../demo-app'),
     });
-    await target.ready;
+    await target.ready();
     const { loaderConfig } = target.packet;
     porter = new Porter({
       root: path.join(__dirname, '../../../demo-proxy'),

--- a/packages/porter/test/unit/js_module.test.js
+++ b/packages/porter/test/unit/js_module.test.js
@@ -18,7 +18,7 @@ describe('JsModule', function() {
       transpile: { include: [ 'yen' ] },
     });
     await fs.rm(porter.cache.path, { recursive: true, force: true });
-    await porter.ready;
+    await porter.ready();
   });
 
   after(async function() {
@@ -72,7 +72,7 @@ describe('JsModule import CSS', function() {
       },
     });
     await fs.rm(porter.cache.path, { recursive: true, force: true });
-    await porter.ready;
+    await porter.ready();
   });
 
   after(async function() {
@@ -106,7 +106,7 @@ describe('JsModule uglifyOptions', function() {
       }
     });
     await fs.rm(porter.cache.path, { recursive: true, force: true });
-    await porter.ready;
+    await porter.ready();
   });
 
   after(async function() {

--- a/packages/porter/test/unit/json_module.test.js
+++ b/packages/porter/test/unit/json_module.test.js
@@ -17,7 +17,7 @@ describe('WasmModule', function() {
       entries: ['home.js', 'test/suite.js'],
     });
     await fs.rm(porter.cache.path, { recursive: true, force: true });
-    await porter.ready;
+    await porter.ready();
   });
 
   after(async function() {

--- a/packages/porter/test/unit/less_module.test.js
+++ b/packages/porter/test/unit/less_module.test.js
@@ -25,7 +25,7 @@ describe('test/unit/less_module.test.js', function() {
       },
       lessOptions: { javascriptEnabled: true },
     });
-    await porter.ready;
+    await porter.ready();
   });
 
   after(async function() {

--- a/packages/porter/test/unit/module.test.js
+++ b/packages/porter/test/unit/module.test.js
@@ -14,7 +14,7 @@ describe('Module', function() {
       paths: ['components', 'browser_modules'],
       entries: ['home.js', 'test/suite.js']
     });
-    await porter.ready;
+    await porter.ready();
   });
 
   after(async function() {
@@ -35,7 +35,7 @@ describe('Module', function() {
   });
 
   it('should generate compact lock', function() {
-    assert('react-color' in porter.packet.lock);
+    assert('react-color' in porter.packet.dependencies);
     assert(!('react-color' in porter.packet.entries['home.js'].lock));
   });
 

--- a/packages/porter/test/unit/stub.test.js
+++ b/packages/porter/test/unit/stub.test.js
@@ -16,7 +16,7 @@ describe('test/unit/stub.test.js', function() {
       paths: 'app/web',
       entries: [ 'notfound.jsx' ],
     });
-    await porter.ready;
+    await porter.ready();
   });
 
   after(async function() {

--- a/packages/porter/test/unit/ts_module.test.js
+++ b/packages/porter/test/unit/ts_module.test.js
@@ -15,7 +15,7 @@ describe('TsModule', function() {
       root,
       entries: [ 'app.tsx' ],
     });
-    await porter.ready;
+    await porter.ready();
   });
 
   after(async function() {

--- a/packages/porter/test/unit/wasm_module.test.js
+++ b/packages/porter/test/unit/wasm_module.test.js
@@ -16,7 +16,7 @@ describe('WasmModule', function() {
       entries: [ 'home.js' ],
     });
     await fs.rm(porter.cache.path, { recursive: true, force: true });
-    await porter.ready;
+    await porter.ready();
   });
 
   after(async function() {


### PR DESCRIPTION
allow application to custom bundle existence checker with `options.bundle.exists(bundle)`. If not specified, will check against the output files at `options.output.path` instead.

`* bundle[Symbol.iterator]` is changed to always iterate entries in sorted order to make sure the bundle output is idempotent. 

`packet.lock` is now deprecated because the lock data might be intimidating (>= 40 KB uncompressed) in large applications. Further optimization would be compile away these lock data at transpile phase. For now, a more compact and consistent `module.lock` is used.

`module.lock` will now have the dependencies sorted to make sure the returned JSON object is idempotent across porter parsing passes.

Yet another change is making the `porter[get ready()]` into `porter.ready()` to pass pack options, which would be `porter.ready({ minify: true })` at production mode. This method is not necessarily exposed to user land hence shouldn't be a breaking change.

The final result would be reducing the duration of `porter.compileAll()` process by half if `options.bundle.exists(bundle)` returns positive.