### PR TITLE
feat: options.resolve.fallback

### DIFF
--- a/packages/demo-app/browser_modules/test/suite.js
+++ b/packages/demo-app/browser_modules/test/suite.js
@@ -92,3 +92,10 @@ describe('worker from dependency', function() {
     expect(result).to.equal('pong');
   });
 });
+
+describe('neglect node.js core modules', function() {
+  it('should neglect node.js core modules by default', function() {
+    const fontkit = require('fontkit');
+    expect(fontkit.create).to.be.a(Function);
+  });
+});

--- a/packages/demo-app/package.json
+++ b/packages/demo-app/package.json
@@ -31,6 +31,7 @@
     "cropper": "^3.0.0",
     "events": "^3.0.0",
     "expect.js": "^0.3.1",
+    "fontkit": "^1.8.1",
     "glob": "^7.1.2",
     "heredoc": "^1.3.1",
     "iconv-lite": "^0.4.24",

--- a/packages/porter/src/cache.js
+++ b/packages/porter/src/cache.js
@@ -68,6 +68,8 @@ module.exports = class Cache {
       if (salt) debug('cache salt changed from %j to %j', salt, this.salt);
       await fs.mkdir(path.dirname(saltPath), { recursive: true });
       await fs.writeFile(saltPath, this.salt);
+      // mark cache.reloaded to monitor performance regressions
+      this.reloaded = true;
     }
   }
 };

--- a/packages/porter/src/module.js
+++ b/packages/porter/src/module.js
@@ -148,7 +148,7 @@ module.exports = class Module {
       }
     }
 
-    const { packet } = this;
+    const { packet, app } = this;
     if (dep == 'stream') packet.browser.stream = 'readable-stream';
     const specifier = packet.browser[dep] || packet.browser[`${dep}.js`] || dep;
     const mod = dep.startsWith('.')
@@ -157,6 +157,14 @@ module.exports = class Module {
 
     // module is neglected in browser field
     if (mod === false) return mod;
+
+    if (mod == null && app.resolve.fallback.hasOwnProperty(specifier)) {
+      const result = app.resolve.fallback[specifier];
+      // fallback: { fs: false }
+      if (result === false) return (packet.browser[specifier] = result);
+      // fallback: { path: 'path-browserify' }
+      // if (typeof result === 'string') return await app.packet.parseDep(result);
+    }
 
     if (!mod) {
       console.error(new Error(`unmet dependency ${dep} (${this.fpath})`).stack);

--- a/packages/porter/src/porter.js
+++ b/packages/porter/src/porter.js
@@ -37,6 +37,13 @@ function waitFor(mod) {
   });
 }
 
+/**
+ * - https://webpack.js.org/configuration/resolve/#resolvefallback
+ */
+const fallback = {
+  fs: false,
+};
+
 class Porter {
   #readyCache = new Map();
 
@@ -57,6 +64,7 @@ class Porter {
       extensions: [ '*', '.js', '.jsx', '.ts', '.tsx', '.d.ts', '.json', '.css' ],
       alias: {},
       ...opts.resolve,
+      fallback: { ...fallback, ...(opts.resolve && opts.resolve.fallback) },
     };
     resolve.suffixes = resolve.extensions.reduce((result, ext) => {
       if (ext === '*') return result.concat('');

--- a/packages/porter/test/unit/module.test.js
+++ b/packages/porter/test/unit/module.test.js
@@ -22,9 +22,9 @@ describe('Module', function() {
   });
 
   it('should be iteratable with module.family', async function() {
-    const pkg = porter.packet.find({ name: 'lodash' });
+    const packet = porter.packet.find({ name: 'lodash' });
 
-    for (const entry of Object.values(pkg.entries)) {
+    for (const entry of Object.values(packet.entries)) {
       const files = {};
       // family members (descendents) should only be iterated once.
       for (const mod of entry.family) {
@@ -58,5 +58,14 @@ describe('Module', function() {
     await mod.minify();
     assert.ok(mod.cache.minified);
     assert.notEqual(devCache.code, mod.cache.code);
+  });
+
+  it('should neglect node.js core modules such as fs', async function() {
+    const packet = porter.packet.find({ name: 'fontkit' });
+    const mod = packet.files['index.js'];
+    const result = await mod.obtain();
+    // should be optimized away by brfs
+    assert.ok(!result.code.includes('/use.trie'));
+    assert.equal(packet.browser.fs, false);
   });
 });


### PR DESCRIPTION
currently only `{ fs: false }` is added, which handles the unmet dependency warning of 'fs' in fontkit. Further use scenarios might include `{ path: 'path-browserify' }` etc.

- https://webpack.js.org/configuration/resolve/#resolvefallback