### PR TITLE
fix: named imports in cjs modules

### DIFF
--- a/packages/porter/test/unit/named_import.test.js
+++ b/packages/porter/test/unit/named_import.test.js
@@ -153,4 +153,23 @@ import "antd/lib/modal/style/css";`.trim());
     });
     assert.deepEqual(result, 'import differenceBy from "lodash/difference-by";');
   });
+
+  it('should handle cjs require as well', function () {
+    const code = `
+const React = require("react");
+const { Select, Button, Toggle } = require("antd");`;
+  const result = replaceAll(code, {
+    libraryName: 'antd',
+    style: 'css',
+  });
+  assert.deepEqual(result.replace(/;(const|require)/g, ';\n$1').trim(), `
+const React = require("react");
+const Select = require("antd/lib/select");
+const Button = require("antd/lib/button");
+const Toggle = require("antd/lib/toggle");
+require("antd/lib/select/style/css");
+require("antd/lib/button/style/css");
+require("antd/lib/toggle/style/css");
+`.trim());
+  });
 });


### PR DESCRIPTION
monolithic libraries like antd/lodash needs to be `require`d or `import`ed on demand for better perf