### PR TITLE
refactor: skip existence check if app.bundle.exists not specified

### DIFF
--- a/packages/porter/test/unit/packet.test.js
+++ b/packages/porter/test/unit/packet.test.js
@@ -24,6 +24,13 @@ describe('Packet', function() {
           '@/': '',
         },
       },
+      bundle: {
+        async exists(bundle) {
+          const { app } = bundle;
+          const fpath = path.join(app.output.path, bundle.outputPath);
+          return await fs.access(fpath).then(() => true).catch(() => false);
+        }
+      }
     });
     await fs.rm(porter.cache.path, { recursive: true, force: true });
     await porter.ready();


### PR DESCRIPTION
there was a 60s~70s build perf regression in our app (260s -> 330s), skip the existence check if not specified and see if this is the cause