### PR TITLE
fix: wasm/workercompilation minor issues

### DIFF
--- a/packages/porter/loader.js
+++ b/packages/porter/loader.js
@@ -247,7 +247,8 @@
 
     if (rUri.test(id)) return id;
 
-    var isRootEntry = registry[id].parent.id in system.entries;
+    var mod = registry[id];
+    var isRootEntry = !mod.parent || (mod.parent.id in system.entries);
     var obj = parseId(id);
     var name = obj.name;
     var version = obj.version;
@@ -524,10 +525,9 @@
     }
     id = suffix(id);
     var mod = registry[id] || new Module(id);
-
     mod.deps = deps;
     mod.factory = factory;
-    mod.status = MODULE_FETCHED;
+    if (mod.status < MODULE_FETCHED) mod.status = MODULE_FETCHED;
     mod.resolve();
   }
 
@@ -552,7 +552,7 @@
 
   function workerFactory(context) {
     return function(id) {
-      var url = basePath + resolve(context, suffix(id));
+      var url = parseUri(resolve(context, suffix(id)));
       return function createWorker() {
         return new Worker([url, 'main'].join(url.indexOf('?') > 0 ? '&' : '?'));
       };

--- a/packages/porter/src/packet.js
+++ b/packages/porter/src/packet.js
@@ -564,8 +564,8 @@ module.exports = class Packet {
       })();
     });
 
-    for (const mod of Object.values(this.entries)) {
-      if (mod.isRootEntry) entries.push(mod.file);
+    for (const mod of Object.values(this.files)) {
+      if (mod.isRootEntry || mod.file.endsWith('.wasm')) entries.push(mod.file);
     }
 
     // if packet won't be bundled with root entries, compile as main bundle.
@@ -607,15 +607,15 @@ module.exports = class Packet {
   async compileAll(opts) {
     const { entries, files, bundles, main } = this;
 
-    for (const entry in entries) {
-      if (entry.endsWith('.js') && entries[entry].isRootEntry) {
-        bundles[entry] = await this.compile(entry, opts);
-      }
-    }
-
     for (const file in files) {
       if (file.endsWith('.wasm')) {
         bundles[file] = await this.compile(file, opts);
+      }
+    }
+
+    for (const entry in entries) {
+      if (entry.endsWith('.js') && entries[entry].isRootEntry) {
+        bundles[entry] = await this.compile(entry, opts);
       }
     }
 


### PR DESCRIPTION
- web workers output paths should present in manifest
- wasm context modules might be defined twice, not sure how that happened exactly
- wasm output paths should be ready before compile the rest of the packet