### PR TITLE
refactor: simplify Module.resolve() in loader.js

### DIFF
--- a/packages/demo-worker/components/test/suite.js
+++ b/packages/demo-worker/components/test/suite.js
@@ -1,4 +1,5 @@
 import Worker from 'worker-loader!../worker.js';
+import HelloWorker from '@cara/hello-worker';
 import expect from 'expect.js';
 import 'regenerator-runtime';
 
@@ -10,5 +11,14 @@ describe('demo-worker', function() {
       done();
     };
     worker.postMessage('ping');
+  });
+
+  it('should support workers in dependencies', function(done) {
+    const worker = new HelloWorker();
+    worker.onmessage = function onMessage(event) {
+      expect(event.data).to.eql('matata');
+      done();
+    };
+    worker.postMessage('hakuna');
   });
 });

--- a/packages/demo-worker/package.json
+++ b/packages/demo-worker/package.json
@@ -10,12 +10,13 @@
   "devDependencies": {
     "@babel/core": "^7.16.0",
     "@babel/preset-env": "^7.10.3",
+    "@cara/hello-worker": "^4.0.0-beta.14",
     "@cara/porter-cli": "^4.0.0-beta.14",
     "expect.js": "^0.3.1",
     "mocha": "^9.1.1"
   },
   "scripts": {
-    "start": "rm -rf public && DEBUG=porter,$DEBUG porter serve",
-    "test": "rm -rf public && DEBUG=porter,$DEBUG porter serve --headless"
+    "start": "rm -rf public && DEBUG=porter,$DEBUG porter serve --include @cara/hello-worker",
+    "test": "rm -rf public && DEBUG=porter,$DEBUG porter serve --include @cara/hello-worker --headless"
   }
 }

--- a/packages/hello-worker/.eslintrc
+++ b/packages/hello-worker/.eslintrc
@@ -1,0 +1,8 @@
+{
+  "parserOptions": {
+    "sourceType": "module"
+  },
+  "env": {
+    "worker": true
+  }
+}

--- a/packages/hello-worker/index.js
+++ b/packages/hello-worker/index.js
@@ -1,0 +1,2 @@
+import Worker from 'worker-loader!./worker.js';
+export default Worker;

--- a/packages/hello-worker/package.json
+++ b/packages/hello-worker/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "@cara/hello-worker",
+  "version": "4.0.0-beta.14",
+  "private": true
+}

--- a/packages/hello-worker/worker.js
+++ b/packages/hello-worker/worker.js
@@ -1,0 +1,3 @@
+onmessage = function() {
+  postMessage('matata');
+};


### PR DESCRIPTION
to better handle following scenarios:

- import app components without name/version prefix
- import dependencies with name/version prefix
- import workers in dependencies with name/version prefix, which means the entry module is prefixed as well
- import app components with name/version prefix, which is possible when writing library tests