### PR TITLE
fix: should skip uri parsing if mapped result starts with '/'

### DIFF
--- a/packages/porter/loader.js
+++ b/packages/porter/loader.js
@@ -240,7 +240,7 @@
    * - //example.com/baz.js
    * - /qux/quux.js
    */
-  var rUri = /^(?:https?:)?\/\//;
+  var rUri = /^(?:https?:)?\//;
 
   function parseUri(id) {
     var id = parseMap(id);


### PR DESCRIPTION
might be mapped as local module