### PR TITLE
refactor: reduce module check when packing packet

### DIFF
--- a/packages/porter/src/bundle.js
+++ b/packages/porter/src/bundle.js
@@ -123,7 +123,7 @@ module.exports = class Bundle {
           if (mod.preloaded && !preload && !packet.isolated) continue;
           if (mod.packet !== packet && mod.packet.isolated) continue;
         }
-        // might be WasmModule
+        // might be WasmModule or web worker
         if (mod.isolated || (format === '.js' && mod.isRootEntry)) continue;
         yield* iterateEntry(mod, preload);
       }

--- a/packages/porter/src/packet.js
+++ b/packages/porter/src/packet.js
@@ -565,15 +565,18 @@ module.exports = class Packet {
     });
 
     for (const mod of Object.values(this.files)) {
-      if (mod.isRootEntry) entries.push(mod.file);
-      // .wasm needs to be bundled before other entries to generate correct manifest
-      if (mod.file.endsWith('.wasm')) entries.unshift(mod.file);
+      if (mod.isRootEntry) {
+        entries.push(mod.file);
+      } else if (mod.file.endsWith('.wasm')) {
+        // .wasm needs to be bundled before other entries to generate correct manifest
+        entries.unshift(mod.file);
+      }
     }
 
     // if packet won't be bundled with root entries, compile as main bundle.
     if (app.preload.length === 0 || isolated || lazyloaded) entries.push(main);
 
-    for (const entry of entries) {
+    for (const entry of new Set(entries)) {
       const bundle = bundles[entry] || Bundle.create({
         packet: this,
         entries: entry === main ? null : [ entry ],

--- a/packages/porter/test/unit/packet.test.js
+++ b/packages/porter/test/unit/packet.test.js
@@ -297,6 +297,17 @@ describe('Packet with WebAssembly', function() {
     await porter.destroy();
   });
 
+  describe('packet.pack()', function() {
+    it('should pack .wasm first', async function() {
+      const packet = porter.packet.find({ name: '@cara/hello-wasm' });
+      await packet.pack();
+      assert.deepEqual(Object.keys(packet.bundles), [
+        'pkg/bundler/index_bg.wasm',
+        'index.js',
+      ]);
+    });
+  });
+
   describe('packet.compileAll()', function() {
     it('should compile wasm as well', async function() {
       const packet = porter.packet.find({ name: '@cara/hello-wasm' });


### PR DESCRIPTION
- added tests covering the logic that the `.wasm` entries need to be put before other entries